### PR TITLE
fix(user): dont return password field in  change-password route

### DIFF
--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -130,12 +130,14 @@ export class UserService {
   public async changePassword(
     user: User,
     changePasswordDTO: ChangePasswordDTO
-  ): Promise<User> {
+  ): Promise<UserDTO> {
     const hashedPassword = await bcrypt.hash(changePasswordDTO.password, 10);
-    return this.prismaService.user.update({
+    const updatedUser = await this.prismaService.user.update({
       data: { password: hashedPassword },
       where: { id: user.id },
     });
+
+    return UserService.convertToDTO(updatedUser);
   }
 
   public async updateFirstLogin(userId: string): Promise<User> {


### PR DESCRIPTION
## Description

- converts Prisma's User type to UserDTO to prevent password from being sent

## Checklist

_First, create a draft pull request. Then mark the PR as ready for review when all necessary checkbox items has been completed_

- [x] Reviewed own code
- [ ] Commented on code that is hard to understand
- [ ] Implemented tests for the feature/bugfix
- [x] All GitHub status checks pass
- [x] The frontend and backend PR previews have been deployed

**Backend only**

- [ ] Added test data for new entity
- [ ] Generated the client api if there are new or deleted endpoints and/or DTOs
