### PR TITLE
feat(organizers): PNRN-5 add organizer frontend CRUD operations

### DIFF
--- a/frontend/src/modules/accounts/components/AccountEditForm.tsx
+++ b/frontend/src/modules/accounts/components/AccountEditForm.tsx
@@ -1,17 +1,11 @@
-import {
-  Button,
-  Checkbox as ChakraCheckbox,
-  Flex,
-  FormControl,
-  FormLabel,
-  Spacer,
-} from '@chakra-ui/react';
+import { Button, Flex, FormControl, FormLabel, Spacer } from '@chakra-ui/react';
 import { Field, FieldProps, Form, Formik } from 'formik';
 import { RegisterUserDTORolesEnum, UserDTO } from 'generated-api';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import * as Yup from 'yup';
 import {
+  Checkbox,
   FormikResetEffect,
   FormLayout,
   Input,
@@ -45,7 +39,10 @@ export const AccountEditForm = ({
   });
 
   const onSubmit = (userDTO: UserDTO) => {
-    if (initialUser.name === userDTO.name) {
+    if (
+      initialUser.name === userDTO.name &&
+      initialUser.roles === userDTO.roles
+    ) {
       if (onComplete) {
         onComplete(userDTO);
       }
@@ -119,18 +116,16 @@ export const AccountEditForm = ({
                   name='roles'
                   type='checkbox'
                   value={RegisterUserDTORolesEnum.Admin}
+                  isChecked
                 >
                   {(fieldProps: FieldProps<string, UserDTO>) => (
-                    <Input
-                      as={ChakraCheckbox}
+                    <Checkbox
                       fieldProps={fieldProps}
                       name='roles'
-                      borderWidth='0px'
-                      type='checkbox'
                       id='admin-role'
                     >
                       {fieldProps.field.value}
-                    </Input>
+                    </Checkbox>
                   )}
                 </Field>
                 <Field
@@ -139,16 +134,13 @@ export const AccountEditForm = ({
                   value={RegisterUserDTORolesEnum.Staff}
                 >
                   {(fieldProps: FieldProps<string, UserDTO>) => (
-                    <Input
-                      as={ChakraCheckbox}
+                    <Checkbox
                       fieldProps={fieldProps}
                       name='roles'
-                      borderWidth='0px'
-                      type='checkbox'
                       id='staff-role'
                     >
                       {fieldProps.field.value}
-                    </Input>
+                    </Checkbox>
                   )}
                 </Field>
                 <Field
@@ -157,16 +149,13 @@ export const AccountEditForm = ({
                   value={RegisterUserDTORolesEnum.Organizer}
                 >
                   {(fieldProps: FieldProps<string, UserDTO>) => (
-                    <Input
-                      as={ChakraCheckbox}
+                    <Checkbox
                       fieldProps={fieldProps}
                       name='roles'
-                      borderWidth='0px'
-                      type='checkbox'
                       id='organizer-role'
                     >
                       {fieldProps.field.value}
-                    </Input>
+                    </Checkbox>
                   )}
                 </Field>
               </Flex>
@@ -185,7 +174,7 @@ export const AccountEditForm = ({
             </Field>
           </FormLayout>
           <Flex w='full' h='full'>
-            <Button type='reset'>Clear Inputs</Button>
+            <Button type='reset'>Reset Inputs</Button>
             <Spacer />
             <Button
               variant='solid'

--- a/frontend/src/modules/accounts/components/AccountRegisterForm.tsx
+++ b/frontend/src/modules/accounts/components/AccountRegisterForm.tsx
@@ -1,16 +1,10 @@
-import {
-  Button,
-  Checkbox as ChakraCheckbox,
-  Flex,
-  FormControl,
-  FormLabel,
-  Spacer,
-} from '@chakra-ui/react';
+import { Button, Flex, FormControl, FormLabel, Spacer } from '@chakra-ui/react';
 import { Field, FieldProps, Form, Formik } from 'formik';
 import { RegisterUserDTO, RegisterUserDTORolesEnum } from 'generated-api';
 import { useEffect } from 'react';
 import * as Yup from 'yup';
 import {
+  Checkbox,
   FormikResetEffect,
   FormLayout,
   Input,
@@ -122,16 +116,14 @@ export const AccountRegisterForm = ({
                   value={RegisterUserDTORolesEnum.Admin}
                 >
                   {(fieldProps: FieldProps<string, RegisterUserDTO>) => (
-                    <Input
-                      as={ChakraCheckbox}
+                    <Checkbox
                       fieldProps={fieldProps}
                       name='roles'
-                      borderWidth='0px'
-                      type='checkbox'
+                      checked={fieldProps.field.checked}
                       id='admin-role'
                     >
                       {fieldProps.field.value}
-                    </Input>
+                    </Checkbox>
                   )}
                 </Field>
                 <Field
@@ -140,16 +132,13 @@ export const AccountRegisterForm = ({
                   value={RegisterUserDTORolesEnum.Staff}
                 >
                   {(fieldProps: FieldProps<string, RegisterUserDTO>) => (
-                    <Input
-                      as={ChakraCheckbox}
+                    <Checkbox
                       fieldProps={fieldProps}
                       name='roles'
-                      borderWidth='0px'
-                      type='checkbox'
                       id='staff-role'
                     >
                       {fieldProps.field.value}
-                    </Input>
+                    </Checkbox>
                   )}
                 </Field>
                 <Field
@@ -158,17 +147,15 @@ export const AccountRegisterForm = ({
                   value={RegisterUserDTORolesEnum.Organizer}
                 >
                   {(fieldProps: FieldProps<string, RegisterUserDTO>) => (
-                    <Input
-                      as={ChakraCheckbox}
+                    <Checkbox
                       fieldProps={fieldProps}
                       name='roles'
-                      borderWidth='0px'
-                      type='checkbox'
+                      checked={fieldProps.field.checked}
                       id='organizer-rol
                       e'
                     >
                       {fieldProps.field.value}
-                    </Input>
+                    </Checkbox>
                   )}
                 </Field>
               </Flex>
@@ -176,7 +163,7 @@ export const AccountRegisterForm = ({
           </FormLayout>
           <Flex w='full' h='full'>
             <Button type='reset' onClick={handleReset}>
-              Clear Inputs
+              Reset Inputs
             </Button>
             <Spacer />
             <Button

--- a/frontend/src/modules/accounts/components/AccountRegisterSuccess.tsx
+++ b/frontend/src/modules/accounts/components/AccountRegisterSuccess.tsx
@@ -1,0 +1,74 @@
+import {
+  Button,
+  Flex,
+  Icon,
+  IconButton,
+  Input,
+  InputGroup,
+  InputRightElement,
+  Spacer,
+  Text,
+} from '@chakra-ui/react';
+import { RegisterUserDTO } from 'generated-api';
+import { useState } from 'react';
+import { BiCheckCircle } from 'react-icons/bi';
+import { FaEye, FaEyeSlash } from 'react-icons/fa';
+import { FormLayout } from '../../../shared/components/form';
+
+interface AccountRegisterSuccessProps {
+  registerDTO: RegisterUserDTO | undefined;
+  onClose: () => void;
+  onRepeat: () => void;
+}
+
+export const AccountRegisterSuccess = ({
+  registerDTO,
+  onClose,
+  onRepeat,
+}: AccountRegisterSuccessProps) => {
+  const [showPassword, setShowPassword] = useState(false);
+
+  return (
+    <>
+      <FormLayout>
+        <Flex direction='column' gap={3}>
+          <Icon as={BiCheckCircle} boxSize='2rem' color='green.500' />
+          <Text>Email: {registerDTO?.email}</Text>
+          <Text>Name: {registerDTO?.name}</Text>
+          <Text>Roles: {registerDTO?.roles.join(', ')}</Text>
+          <Text>Password: </Text>
+          <InputGroup>
+            <InputRightElement
+              alignItems='center'
+              justifyContent='center'
+              h={10}
+              px='4'
+            >
+              <IconButton
+                aria-label='Show password'
+                size='sm'
+                variant='ghost'
+                icon={showPassword ? <FaEye /> : <FaEyeSlash />}
+                onClick={() => setShowPassword(!showPassword)}
+              />
+            </InputRightElement>
+
+            <Input
+              name='password'
+              type={showPassword ? 'text' : 'password'}
+              id='password'
+              value={registerDTO?.password}
+            />
+          </InputGroup>
+        </Flex>
+      </FormLayout>
+      <Flex>
+        <Spacer />
+        <Button onClick={onClose}>Close</Button>
+        <Button variant='solid' onClick={onRepeat} ml={2}>
+          Register Again
+        </Button>
+      </Flex>
+    </>
+  );
+};

--- a/frontend/src/modules/accounts/components/Accounts.tsx
+++ b/frontend/src/modules/accounts/components/Accounts.tsx
@@ -1,27 +1,81 @@
+import { Button, useDisclosure } from '@chakra-ui/react';
+import { RegisterUserDTO } from 'generated-api';
+import { useState } from 'react';
+import { AccountRegisterForm } from '.';
 import {
   ContentHeader,
   ContentSection,
 } from '../../../shared/components/content';
-import { LinkButton } from '../../../shared/components/elements';
+import { Modal } from '../../../shared/components/elements';
 import { MainLayout } from '../../../shared/components/layout';
+import { AccountRegisterSuccess } from './AccountRegisterSuccess';
 import { AccountsTable } from './AccountsTable';
 
 export const Accounts = () => {
+  const [refresh, setRefresh] = useState(false);
+  const [registerDTO, setRegisterDTO] = useState<RegisterUserDTO | undefined>(
+    undefined
+  );
+
+  const {
+    onOpen: onRegisterOpen,
+    isOpen: isRegisterOpen,
+    onClose: onRegisterClose,
+  } = useDisclosure();
+
+  const {
+    onOpen: onSuccessOpen,
+    isOpen: isSuccessOpen,
+    onClose: onSuccessClose,
+  } = useDisclosure();
+
+  const handleComplete = (registeredUser: RegisterUserDTO) => {
+    setRegisterDTO(registeredUser);
+    onRegisterClose();
+    onSuccessOpen();
+    setRefresh(!refresh);
+  };
+
+  const handleRegisterAgain = () => {
+    setRegisterDTO(undefined);
+    onRegisterOpen();
+    onSuccessClose();
+  };
+
   return (
     <MainLayout>
       <ContentHeader
         title='Accounts'
         actions={
-          <LinkButton
-            variant='solid'
-            label='Register Account'
-            route='/accounts/register'
-          />
+          <Button variant='solid' onClick={onRegisterOpen}>
+            Register Account
+          </Button>
         }
       />
+
       <ContentSection>
-        <AccountsTable />
+        <AccountsTable refresh={refresh} />
       </ContentSection>
+
+      <Modal
+        title='Account Edit'
+        isOpen={isRegisterOpen}
+        onClose={onRegisterClose}
+      >
+        <AccountRegisterForm onComplete={handleComplete} />
+      </Modal>
+
+      <Modal
+        title='Register Success'
+        isOpen={isSuccessOpen}
+        onClose={onSuccessClose}
+      >
+        <AccountRegisterSuccess
+          registerDTO={registerDTO}
+          onClose={onSuccessClose}
+          onRepeat={handleRegisterAgain}
+        />
+      </Modal>
     </MainLayout>
   );
 };

--- a/frontend/src/modules/organizers/components/OrganizerAddForm.tsx
+++ b/frontend/src/modules/organizers/components/OrganizerAddForm.tsx
@@ -1,0 +1,101 @@
+import { Button, Flex, Spacer } from '@chakra-ui/react';
+import { Field, FieldProps, Form, Formik } from 'formik';
+import { OrganizerDTO, OrganizerDTOTypeEnum } from 'generated-api';
+import { useEffect } from 'react';
+import * as Yup from 'yup';
+import { FormLayout, Input, Select } from '../../../shared/components/form';
+import { useToast } from '../../../shared/hooks';
+import { useOrganizers } from '../hooks';
+
+interface OrganizerAddFormProps {
+  onComplete: (organizer: OrganizerDTO) => void;
+}
+
+export const OrganizerAddForm = ({ onComplete }: OrganizerAddFormProps) => {
+  const { addOrganizer } = useOrganizers();
+  const toast = useToast();
+
+  const onSubmit = (organizer: OrganizerDTO) => {
+    addOrganizer.mutate(organizer);
+  };
+
+  const initialValues = {
+    name: '',
+    type: OrganizerDTOTypeEnum.Department,
+  };
+
+  const validationSchema = Yup.object({
+    name: Yup.string().min(1).max(65).required('Required'),
+    type: Yup.string().min(1).max(50).required('Required'),
+  });
+
+  useEffect(() => {
+    if (addOrganizer.isSuccess) {
+      toast({ title: 'Added organizer successfully' });
+      onComplete(addOrganizer.data.data);
+    }
+  }, [addOrganizer, onComplete, toast]);
+
+  return (
+    <Formik
+      initialValues={initialValues}
+      validationSchema={validationSchema}
+      onSubmit={onSubmit}
+    >
+      {() => (
+        <Form noValidate>
+          <FormLayout>
+            <Field name='name' type='name' isRequired>
+              {(fieldProps: FieldProps<string, OrganizerDTO>) => (
+                <Input
+                  fieldProps={fieldProps}
+                  name='name'
+                  label='Name'
+                  type='name'
+                  id='name'
+                  placeholder='College of Engineering and Architecture'
+                  isRequired
+                />
+              )}
+            </Field>
+            <Field name='type' type='text' isRequired>
+              {(fieldProps: FieldProps<string, OrganizerDTO>) => (
+                <Select
+                  fieldProps={fieldProps}
+                  name='type'
+                  label='Type'
+                  id='type'
+                  isRequired
+                >
+                  <option value={OrganizerDTOTypeEnum.Department}>
+                    {OrganizerDTOTypeEnum.Department.toString()}
+                  </option>
+                  <option value={OrganizerDTOTypeEnum.Organization}>
+                    {OrganizerDTOTypeEnum.Organization.toString()}
+                  </option>
+                  <option value={OrganizerDTOTypeEnum.Others}>
+                    {OrganizerDTOTypeEnum.Others.toString()}
+                  </option>
+                </Select>
+              )}
+            </Field>
+          </FormLayout>
+          <Flex w='full' h='full'>
+            <Button type='reset'>Reset Inputs</Button>
+            <Spacer />
+            <Button
+              variant='solid'
+              data-cy='add-submit-btn'
+              formNoValidate
+              type='submit'
+              isLoading={addOrganizer.isLoading}
+              loadingText='Adding...'
+            >
+              Add Organizer
+            </Button>
+          </Flex>
+        </Form>
+      )}
+    </Formik>
+  );
+};

--- a/frontend/src/modules/organizers/components/OrganizerAddSuccess.tsx
+++ b/frontend/src/modules/organizers/components/OrganizerAddSuccess.tsx
@@ -1,0 +1,35 @@
+import { Button, Flex, Icon, Spacer, Text } from '@chakra-ui/react';
+import { OrganizerDTO } from 'generated-api';
+import { BiCheckCircle } from 'react-icons/bi';
+import { FormLayout } from '../../../shared/components/form';
+
+interface OrganizerAddSuccessProps {
+  organizerDTO: OrganizerDTO | undefined;
+  onClose: () => void;
+  onRepeat: () => void;
+}
+
+export const OrganizerAddSuccess = ({
+  organizerDTO,
+  onClose,
+  onRepeat,
+}: OrganizerAddSuccessProps) => {
+  return (
+    <>
+      <FormLayout>
+        <Flex direction='column' gap={3}>
+          <Icon as={BiCheckCircle} boxSize='2rem' color='green.500' />
+          <Text>Name: {organizerDTO?.name}</Text>
+          <Text>Type: {organizerDTO?.type}</Text>
+        </Flex>
+      </FormLayout>
+      <Flex>
+        <Spacer />
+        <Button onClick={onClose}>Close</Button>
+        <Button variant='solid' onClick={onRepeat} ml={2}>
+          Add Again
+        </Button>
+      </Flex>
+    </>
+  );
+};

--- a/frontend/src/modules/organizers/components/OrganizerEditForm.tsx
+++ b/frontend/src/modules/organizers/components/OrganizerEditForm.tsx
@@ -1,0 +1,104 @@
+import { Button, Flex, Spacer } from '@chakra-ui/react';
+import { Field, FieldProps, Form, Formik } from 'formik';
+import { OrganizerDTO, OrganizerDTOTypeEnum } from 'generated-api';
+import { useEffect } from 'react';
+import * as Yup from 'yup';
+import { FormLayout, Input, Select } from '../../../shared/components/form';
+import { useToast } from '../../../shared/hooks';
+import { useOrganizers } from '../hooks';
+
+interface OrganizerAddFormProps {
+  initialOrganizer: OrganizerDTO;
+  onComplete: (organizer: OrganizerDTO) => void;
+}
+
+export const OrganizerEditForm = ({
+  initialOrganizer,
+  onComplete,
+}: OrganizerAddFormProps) => {
+  const { editOrganizer } = useOrganizers();
+  const toast = useToast();
+
+  const onSubmit = (organizer: OrganizerDTO) => {
+    editOrganizer.mutate(organizer);
+  };
+
+  const initialValues = {
+    ...initialOrganizer,
+  };
+
+  const validationSchema = Yup.object({
+    name: Yup.string().min(1).max(65).required('Required'),
+    type: Yup.string().min(1).max(50).required('Required'),
+  });
+
+  useEffect(() => {
+    if (editOrganizer.isSuccess) {
+      toast({ title: 'Edited organizer successfully' });
+      onComplete(editOrganizer.data.data);
+    }
+  }, [editOrganizer, onComplete, toast]);
+
+  return (
+    <Formik
+      initialValues={initialValues}
+      validationSchema={validationSchema}
+      onSubmit={onSubmit}
+    >
+      {() => (
+        <Form noValidate>
+          <FormLayout>
+            <Field name='name' type='name' isRequired>
+              {(fieldProps: FieldProps<string, OrganizerDTO>) => (
+                <Input
+                  fieldProps={fieldProps}
+                  name='name'
+                  label='Name'
+                  type='name'
+                  id='name'
+                  placeholder='College of Engineering and Architecture'
+                  isRequired
+                />
+              )}
+            </Field>
+            <Field name='type' type='text' isRequired>
+              {(fieldProps: FieldProps<string, OrganizerDTO>) => (
+                <Select
+                  fieldProps={fieldProps}
+                  name='type'
+                  label='Type'
+                  id='type'
+                  isRequired
+                >
+                  <option value={OrganizerDTOTypeEnum.Department}>
+                    {OrganizerDTOTypeEnum.Department.toString()}
+                  </option>
+                  <option value={OrganizerDTOTypeEnum.Organization}>
+                    {OrganizerDTOTypeEnum.Organization.toString()}
+                  </option>
+                  <option value={OrganizerDTOTypeEnum.Others}>
+                    {OrganizerDTOTypeEnum.Others.toString()}
+                  </option>
+                </Select>
+              )}
+            </Field>
+          </FormLayout>
+          <Flex w='full' h='full'>
+            <Button type='reset'>Reset Inputs</Button>
+            <Spacer />
+            <Button
+              variant='solid'
+              data-cy='edit-submit-btn'
+              formNoValidate
+              type='submit'
+              isLoading={editOrganizer.isLoading}
+              loadingText='Editing...'
+            >
+              Edit Organizer
+            </Button>
+          </Flex>
+        </Form>
+      )}
+    </Formik>
+  );
+};

--- a/frontend/src/modules/organizers/components/Organizers.tsx
+++ b/frontend/src/modules/organizers/components/Organizers.tsx
@@ -1,0 +1,82 @@
+import { Button, useDisclosure } from '@chakra-ui/react';
+import { OrganizerDTO } from 'generated-api';
+import { useState } from 'react';
+import {
+  ContentHeader,
+  ContentSection,
+} from '../../../shared/components/content';
+import { Modal } from '../../../shared/components/elements';
+import { MainLayout } from '../../../shared/components/layout';
+import { OrganizerAddForm } from './OrganizerAddForm';
+import { OrganizerAddSuccess } from './OrganizerAddSuccess';
+import { OrganizersTable } from './OrganizersTable';
+
+export const Organizers = () => {
+  const [refresh, setRefresh] = useState(false);
+  const [newOrganizerDTO, setOrganizerDTO] = useState<OrganizerDTO | undefined>(
+    undefined
+  );
+
+  const {
+    onOpen: onAddOpen,
+    isOpen: isAddOpen,
+    onClose: onClose,
+  } = useDisclosure();
+
+  const {
+    onOpen: onSuccessOpen,
+    isOpen: isSuccessOpen,
+    onClose: onSuccessClose,
+  } = useDisclosure();
+
+  const handleComplete = (newOrganizer: OrganizerDTO) => {
+    setOrganizerDTO(newOrganizer);
+    onClose();
+    onSuccessOpen();
+  };
+
+  const handleRegisterAgain = () => {
+    setOrganizerDTO(undefined);
+    onAddOpen();
+    onSuccessClose();
+  };
+
+  const handleSuccessClose = () => {
+    setOrganizerDTO(undefined);
+    onSuccessClose();
+    setRefresh(!refresh);
+  };
+
+  return (
+    <MainLayout>
+      <ContentHeader
+        title='Organizers'
+        actions={
+          <Button variant='solid' onClick={onAddOpen}>
+            Add Organizer
+          </Button>
+        }
+      />
+
+      <ContentSection>
+        <OrganizersTable refresh={refresh} />
+      </ContentSection>
+
+      <Modal title='Organizer Edit' isOpen={isAddOpen} onClose={onClose}>
+        <OrganizerAddForm onComplete={handleComplete} />
+      </Modal>
+
+      <Modal
+        title='Add Success'
+        isOpen={isSuccessOpen}
+        onClose={onSuccessClose}
+      >
+        <OrganizerAddSuccess
+          organizerDTO={newOrganizerDTO}
+          onClose={handleSuccessClose}
+          onRepeat={handleRegisterAgain}
+        />
+      </Modal>
+    </MainLayout>
+  );
+};

--- a/frontend/src/modules/organizers/components/index.ts
+++ b/frontend/src/modules/organizers/components/index.ts
@@ -1,0 +1,5 @@
+export * from './Organizers';
+export * from './OrganizersTable';
+export * from './OrganizerAddForm';
+export * from './OrganizerEditForm';
+export * from './OrganizerAddSuccess';

--- a/frontend/src/modules/organizers/hooks/index.ts
+++ b/frontend/src/modules/organizers/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useOrganizers';

--- a/frontend/src/modules/organizers/hooks/useOrganizers.ts
+++ b/frontend/src/modules/organizers/hooks/useOrganizers.ts
@@ -1,0 +1,26 @@
+import { OrganizerDTO } from 'generated-api';
+import { useContext } from 'react';
+import { useMutation } from 'react-query';
+import { ApiContext } from '../../../shared/providers/ApiProvider';
+
+export const useOrganizers = () => {
+  const api = useContext(ApiContext);
+
+  const addOrganizer = useMutation((organizerDTO: OrganizerDTO) =>
+    api.createNewOrganizer(organizerDTO)
+  );
+
+  const editOrganizer = useMutation((organizerDTO: OrganizerDTO) =>
+    api.updateOrganizer(organizerDTO.id as string, organizerDTO)
+  );
+
+  const fetchOrganizerById = useMutation((id: string) =>
+    api.getOrganizerByID(id)
+  );
+
+  return {
+    addOrganizer,
+    editOrganizer,
+    fetchOrganizerById,
+  };
+};

--- a/frontend/src/modules/organizers/index.ts
+++ b/frontend/src/modules/organizers/index.ts
@@ -1,0 +1,2 @@
+export * from './components';
+export * from './hooks';

--- a/frontend/src/modules/settings/components/ChangePassword.tsx
+++ b/frontend/src/modules/settings/components/ChangePassword.tsx
@@ -1,6 +1,9 @@
 import { UserDTO } from 'generated-api';
 import { useRouter } from 'next/router';
-import { ContentHeader } from '../../../shared/components/content';
+import {
+  ContentHeader,
+  ContentSection,
+} from '../../../shared/components/content';
 import { MainLayout } from '../../../shared/components/layout';
 import { useToast } from '../../../shared/hooks';
 import { useGlobalStore } from '../../../shared/stores';
@@ -23,7 +26,9 @@ export const ChangePassword = () => {
   return (
     <MainLayout>
       <ContentHeader title='Change Password' />
-      <ChangePasswordForm onComplete={handleComplete} />
+      <ContentSection>
+        <ChangePasswordForm onComplete={handleComplete} />
+      </ContentSection>
     </MainLayout>
   );
 };

--- a/frontend/src/modules/settings/components/ChangePasswordForm.tsx
+++ b/frontend/src/modules/settings/components/ChangePasswordForm.tsx
@@ -1,5 +1,4 @@
 import {
-  Box,
   Button,
   Flex,
   FormLabel,
@@ -13,7 +12,7 @@ import { ChangePasswordDTO, UserDTO } from 'generated-api';
 import { useEffect, useState } from 'react';
 import { FaEye, FaEyeSlash } from 'react-icons/fa';
 import * as Yup from 'yup';
-import { Input } from '../../../shared/components/form';
+import { FormLayout, Input } from '../../../shared/components/form';
 import {
   confirmPasswordValidator,
   passwordValidator,
@@ -57,72 +56,75 @@ export const ChangePasswordForm = ({ onComplete }: ChangePasswordForm) => {
     >
       {() => (
         <Form noValidate>
-          <Box mb='4'>
-            <FormLabel>New Password</FormLabel>
-            <Field name='password' type='password'>
-              {(fieldProps: FieldProps<string, ChangePasswordDTO>) => (
-                <InputGroup>
-                  {fieldProps.field.value?.length > 0 ? (
-                    <InputRightElement
-                      alignItems='center'
-                      justifyContent='center'
-                      h={10}
-                      px='4'
-                    >
-                      <IconButton
-                        aria-label='Show password'
-                        size='sm'
-                        variant='ghost'
-                        icon={showPassword ? <FaEye /> : <FaEyeSlash />}
-                        onClick={() => setShowPassword(!showPassword)}
-                      />
-                    </InputRightElement>
-                  ) : null}
-                  <Input
-                    fieldProps={fieldProps}
-                    name='password'
-                    type={showPassword ? 'text' : 'password'}
-                    id='password'
-                  />
-                </InputGroup>
-              )}
-            </Field>
+          <FormLayout gap={3}>
+            <Flex direction='column'>
+              <FormLabel>New Password</FormLabel>
+              <Field name='password' type='password'>
+                {(fieldProps: FieldProps<string, ChangePasswordDTO>) => (
+                  <InputGroup>
+                    {fieldProps.field.value?.length > 0 ? (
+                      <InputRightElement
+                        alignItems='center'
+                        justifyContent='center'
+                        h={10}
+                        px='4'
+                      >
+                        <IconButton
+                          aria-label='Show password'
+                          size='sm'
+                          variant='ghost'
+                          icon={showPassword ? <FaEye /> : <FaEyeSlash />}
+                          onClick={() => setShowPassword(!showPassword)}
+                        />
+                      </InputRightElement>
+                    ) : null}
+                    <Input
+                      fieldProps={fieldProps}
+                      name='password'
+                      type={showPassword ? 'text' : 'password'}
+                      id='password'
+                    />
+                  </InputGroup>
+                )}
+              </Field>
+            </Flex>
+            <Flex direction='column'>
+              <FormLabel>Confirm New Password</FormLabel>
+              <Field name='confirmPassword' type='confirmPassword'>
+                {(fieldProps: FieldProps<string, ChangePasswordDTO>) => (
+                  <InputGroup>
+                    {fieldProps.field.value?.length > 0 ? (
+                      <InputRightElement
+                        alignItems='center'
+                        justifyContent='center'
+                        h={10}
+                        px='4'
+                      >
+                        <IconButton
+                          aria-label='Show confirm password'
+                          size='sm'
+                          variant='ghost'
+                          icon={showConfimPassword ? <FaEye /> : <FaEyeSlash />}
+                          onClick={() =>
+                            setShowConfirmPassword(!showConfimPassword)
+                          }
+                        />
+                      </InputRightElement>
+                    ) : null}
 
-            <FormLabel>Confirm New Password</FormLabel>
-            <Field name='confirmPassword' type='confirmPassword'>
-              {(fieldProps: FieldProps<string, ChangePasswordDTO>) => (
-                <InputGroup>
-                  {fieldProps.field.value?.length > 0 ? (
-                    <InputRightElement
-                      alignItems='center'
-                      justifyContent='center'
-                      h={10}
-                      px='4'
-                    >
-                      <IconButton
-                        aria-label='Show confirm password'
-                        size='sm'
-                        variant='ghost'
-                        icon={showConfimPassword ? <FaEye /> : <FaEyeSlash />}
-                        onClick={() =>
-                          setShowConfirmPassword(!showConfimPassword)
-                        }
-                      />
-                    </InputRightElement>
-                  ) : null}
-
-                  <Input
-                    fieldProps={fieldProps}
-                    name='confirmPassword'
-                    type={showConfimPassword ? 'text' : 'password'}
-                    id='confirmPassword'
-                  />
-                </InputGroup>
-              )}
-            </Field>
-          </Box>
+                    <Input
+                      fieldProps={fieldProps}
+                      name='confirmPassword'
+                      type={showConfimPassword ? 'text' : 'password'}
+                      id='confirmPassword'
+                    />
+                  </InputGroup>
+                )}
+              </Field>
+            </Flex>
+          </FormLayout>
           <Flex w='full' h='full'>
-            <Button type='reset'>Clear Inputs</Button>
+            <Button type='reset'>Reset Inputs</Button>
             <Spacer />
             <Button
               variant='solid'

--- a/frontend/src/modules/settings/components/Profile.tsx
+++ b/frontend/src/modules/settings/components/Profile.tsx
@@ -1,7 +1,10 @@
 import { UserDTO } from 'generated-api';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
-import { ContentHeader } from '../../../shared/components/content';
+import {
+  ContentHeader,
+  ContentSection,
+} from '../../../shared/components/content';
 import { MainLayout } from '../../../shared/components/layout';
 import { useGlobalStore } from '../../../shared/stores';
 import { ProfileEditForm } from './ProfileEditForm';
@@ -20,7 +23,9 @@ export const Profile = () => {
     <MainLayout>
       <ContentHeader title='Profile Edit' />
       {userDTO && (
-        <ProfileEditForm initialUser={userDTO} onComplete={handleComplete} />
+        <ContentSection>
+          <ProfileEditForm initialUser={userDTO} onComplete={handleComplete} />
+        </ContentSection>
       )}
     </MainLayout>
   );

--- a/frontend/src/modules/settings/components/ProfileEditForm.tsx
+++ b/frontend/src/modules/settings/components/ProfileEditForm.tsx
@@ -102,7 +102,7 @@ export const ProfileEditForm = ({
             </Field>
           </FormLayout>
           <Flex w='full' h='full'>
-            <Button type='reset'>Clear Inputs</Button>
+            <Button type='reset'>Reset Inputs</Button>
             <Spacer />
             <Button
               variant='solid'

--- a/frontend/src/pages/organizers/index.tsx
+++ b/frontend/src/pages/organizers/index.tsx
@@ -1,0 +1,3 @@
+import { Organizers } from '../../modules/organizers';
+
+export default Organizers;

--- a/frontend/src/shared/components/elements/Modal/Modal.tsx
+++ b/frontend/src/shared/components/elements/Modal/Modal.tsx
@@ -1,51 +1,47 @@
 import {
   Modal as ChakraModal,
-  ModalOverlay,
-  ModalContent,
-  ModalHeader,
-  ModalCloseButton,
   ModalBody,
+  ModalCloseButton,
+  ModalContent,
   ModalFooter,
-  Button,
+  ModalHeader,
+  ModalOverlay,
   ModalProps as ChakraModalProps,
 } from '@chakra-ui/react';
 
 interface ModalProps {
-  // modalProps: UseDisclosureProps;
-  title?: string;
+  iconTitle?: React.ReactNode;
+  title: string;
   children: React.PropsWithChildren;
   footer?: React.ReactNode;
 }
 
 export const Modal = ({
+  iconTitle,
   title,
   children,
   footer,
-  // modalProps: { isOpen, onClose },
   isOpen,
   onClose,
   ...props
 }: ModalProps & ChakraModalProps) => {
-  // const { isOpen, onOpen, onClose } = useDisclosure();
-
   return (
     <ChakraModal
-      scrollBehavior='inside'
       motionPreset='slideInBottom'
       isOpen={isOpen}
       onClose={onClose}
+      size='xl'
+      {...props}
     >
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader>{title}</ModalHeader>
+        <ModalHeader>
+          {iconTitle}
+          {title}
+        </ModalHeader>
         <ModalCloseButton />
         <ModalBody>{children}</ModalBody>
-        <ModalFooter>
-          <Button mr={3} onClick={onClose}>
-            Cancel
-          </Button>
-          {footer}
-        </ModalFooter>
+        <ModalFooter>{footer}</ModalFooter>
       </ModalContent>
     </ChakraModal>
   );

--- a/frontend/src/shared/components/form/Checkbox.tsx
+++ b/frontend/src/shared/components/form/Checkbox.tsx
@@ -1,55 +1,34 @@
-import React from 'react';
-import type { FieldProps } from 'formik';
 import {
-  CheckboxProps as ChakraCheckBoxProps,
-  useCheckbox,
-  Flex,
-  chakra,
-  Text,
-  Box,
+  Checkbox as ChakraCheckbox,
+  CheckboxProps as ChakraCheckboxProps,
+  FormControl,
+  FormErrorMessage,
 } from '@chakra-ui/react';
+import type { FieldProps } from 'formik';
+import React from 'react';
 
 interface CheckboxProps {
   fieldProps: FieldProps;
-  label?: string;
 }
 
-export const Checkbox = (
-  props: CheckboxProps & ChakraCheckBoxProps & FieldProps
-) => {
-  const { state, getCheckboxProps, getInputProps, getLabelProps, htmlProps } =
-    useCheckbox(props);
-
-  return (
-    <chakra.label
-      display='flex'
-      flexDirection='row'
-      alignItems='center'
-      gridColumnGap={2}
-      bg='green.50'
-      border='1px solid'
-      borderColor='green.500'
-      rounded='lg'
-      px={3}
-      py={1}
-      cursor='pointer'
-      {...htmlProps}
+export const Checkbox = ({
+  fieldProps: { field, form },
+  children,
+  ...props
+}: CheckboxProps & React.PropsWithChildren & ChakraCheckboxProps) => (
+  <FormControl
+    isInvalid={!!form.errors[props.name!] && !!form.touched[props.name!]}
+    isRequired={props?.isRequired}
+  >
+    <ChakraCheckbox
+      type='checkbox'
+      isChecked={field.checked}
+      my={1}
+      {...field}
+      {...props}
     >
-      <input {...getInputProps()} hidden />
-      <Flex
-        alignItems='center'
-        justifyContent='center'
-        border='2px solid'
-        borderColor='green.500'
-        w={4}
-        h={4}
-        {...getCheckboxProps()}
-      >
-        {state.isChecked && <Box w={2} h={2} bg='green.500' />}
-      </Flex>
-      <Text color='gray.700' {...getLabelProps()}>
-        Click me for {props.value}
-      </Text>
-    </chakra.label>
-  );
-};
+      {children}
+    </ChakraCheckbox>
+    <FormErrorMessage>{form.errors[props.name!]?.toString()}</FormErrorMessage>
+  </FormControl>
+);

--- a/frontend/src/shared/components/form/FormLayout.tsx
+++ b/frontend/src/shared/components/form/FormLayout.tsx
@@ -9,17 +9,7 @@ export const FormLayout = ({
   ...props
 }: ContentSectionProps & FlexProps) => {
   return (
-    <Flex
-      direction='column'
-      bg='foreground'
-      borderWidth='1px'
-      rounded='xl'
-      px={6}
-      py={5}
-      mb={4}
-      gap={5}
-      {...props}
-    >
+    <Flex direction='column' mb={10} gap={4} {...props}>
       {children}
     </Flex>
   );

--- a/frontend/src/shared/components/form/Select.tsx
+++ b/frontend/src/shared/components/form/Select.tsx
@@ -1,0 +1,46 @@
+import {
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  Select as ChakraSelect,
+  SelectProps as ChakraSelectProps,
+  Tooltip,
+} from '@chakra-ui/react';
+import type { FieldProps } from 'formik';
+import React from 'react';
+
+interface SelectProps {
+  label?: string;
+  tooltipLabel?: string;
+  fieldProps: FieldProps;
+}
+
+export const Select = ({
+  fieldProps: { field, form },
+  label,
+  tooltipLabel,
+  children,
+  ...props
+}: SelectProps & React.PropsWithChildren & ChakraSelectProps) => (
+  <FormControl
+    isInvalid={!!form.errors[props.name!] && !!form.touched[props.name!]}
+    isRequired={props?.isRequired}
+  >
+    {!!label && (
+      <FormLabel htmlFor={props.id} mb='2' fontWeight='semibold'>
+        {label}
+      </FormLabel>
+    )}
+    <Tooltip
+      display={props.isReadOnly ? 'block' : 'none'}
+      label={tooltipLabel || `Editing ${props.name} is restricted`}
+      placement='bottom-end'
+      hasArrow
+    >
+      <ChakraSelect {...field} {...props}>
+        {children}
+      </ChakraSelect>
+    </Tooltip>
+    <FormErrorMessage>{form.errors[props.name!]?.toString()}</FormErrorMessage>
+  </FormControl>
+);

--- a/frontend/src/shared/components/form/index.ts
+++ b/frontend/src/shared/components/form/index.ts
@@ -1,4 +1,5 @@
 export * from './Input';
 export * from './Checkbox';
+export * from './Select';
 export * from './FormikResetEffect';
 export * from './FormLayout';

--- a/frontend/src/shared/components/table/TableActions.tsx
+++ b/frontend/src/shared/components/table/TableActions.tsx
@@ -1,0 +1,53 @@
+import {
+  Icon,
+  IconButton,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
+  Portal,
+} from '@chakra-ui/react';
+import { BiDotsVerticalRounded, BiEdit, BiTrash } from 'react-icons/bi';
+
+interface AccountActionsProps<T> {
+  data: T;
+  onDelete: (userDTO: T) => void;
+  onEdit: (userDTO: T) => void;
+}
+
+export const TableActions = <T extends unknown>({
+  data: user,
+  onDelete,
+  onEdit,
+}: AccountActionsProps<T>) => {
+  return (
+    <Menu strategy='absolute' placement='bottom-end'>
+      <MenuButton
+        as={IconButton}
+        aria-label='Open notifications'
+        color='current'
+        rounded='full'
+        icon={<Icon boxSize='1.5rem' as={BiDotsVerticalRounded} />}
+      ></MenuButton>
+      <Portal>
+        <MenuList minW={40} w={20}>
+          <MenuItem
+            icon={<Icon as={BiEdit} boxSize={4} />}
+            onClick={() => onEdit(user)}
+          >
+            Edit
+          </MenuItem>
+          <MenuItem
+            icon={<Icon as={BiTrash} boxSize={4} />}
+            onClick={() => onDelete(user)}
+            bg='errorBg'
+            color='errorColor'
+            borderColor='errorBorder'
+          >
+            Delete
+          </MenuItem>
+        </MenuList>
+      </Portal>
+    </Menu>
+  );
+};

--- a/frontend/src/shared/components/table/index.ts
+++ b/frontend/src/shared/components/table/index.ts
@@ -1,0 +1,1 @@
+export * from './TableActions';

--- a/frontend/src/shared/hooks/useAxios.ts
+++ b/frontend/src/shared/hooks/useAxios.ts
@@ -62,6 +62,7 @@ export const useAxios = ({
             description: toastDescription || description,
             isClosable: true,
             variant: 'subtle',
+            position: 'bottom-right',
           });
         }
       }

--- a/frontend/src/shared/hooks/useToast.ts
+++ b/frontend/src/shared/hooks/useToast.ts
@@ -5,7 +5,7 @@ export const DEFAULT_TOAST_OPTIONS: UseToastOptions = {
   variant: 'subtle',
   position: 'bottom-right',
   status: 'success',
-  duration: 3000,
+  duration: 5000,
 };
 
 export const useToast = () => {


### PR DESCRIPTION
## Description

- Added modal for Accounts Register and Edit
- Added Organizers frontend CRUD operations
- Fixed checklist not responding to user data in AccountEdit form

### Reasons on why implementation is changed from Page to Modal
- Most of the Entity Management forms are very short having 1 or 2 property fields only, this means it looks really weird in full-page renders
- Modal reduces routes to protect as the user needs to access only the parent data table first before performing any CRUD
- Improves UX
- Implicitly signify that current action is still within the context (from Accounts page, editing an Accounts shows a modal form, signifying that the user is still in the Accounts context --- if that makes sense)

## Checklist

- [x] Reviewed own code
- [ ] Commented on code that is hard to understand
- [ ] Implemented tests for the feature/bugfix
- [x] All GitHub status checks pass
- [x] The frontend and backend PR previews have been deployed

**Backend only**

- [ ] Added test data for new entity
- [ ] Generated the client api if there are new or deleted endpoints and/or DTOs
