### PR TITLE
feat(organizers):add case insensitive filtering for organizers

### DIFF
--- a/backend/prisma/migrations/20220906034501_organizer_unique_name/migration.sql
+++ b/backend/prisma/migrations/20220906034501_organizer_unique_name/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[name]` on the table `Organizer` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "Organizer_name_key" ON "Organizer"("name");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -57,7 +57,7 @@ enum Availability {
 
 model Organizer {
   id   String @id @default(uuid())
-  name String
+  name String @unique
   type Type
 }
 

--- a/backend/src/global/test-data/organizer-test-data.service.ts
+++ b/backend/src/global/test-data/organizer-test-data.service.ts
@@ -5,12 +5,12 @@ import { Organizer, Type } from '@prisma/client';
 
 export const testOrganizerDepartment: Organizer = {
   id: '6ee07e9c-daa6-4d13-a96a-91a64d380a2e',
-  name: 'Christopher Lao',
+  name: 'MSDO',
   type: Type.DEPARTMENT,
 };
 export const testOrganizerOrganization: Organizer = {
   id: '906e7fb5-67ac-4632-9c4b-6721833f1264',
-  name: 'Keanue Dax Teaño',
+  name: 'Supreme Student Government',
   type: Type.ORGANIZATION,
 };
 @Injectable()


### PR DESCRIPTION
## Description

Add case-insensitive filtering for organizers name upon creation

## Checklist

- [x] Reviewed own code
- [x] Commented on code that is hard to understand
- [ ] Implemented tests for the feature/bugfix
- [ ] All GitHub status checks pass
- [ ] The frontend and backend PR previews have been deployed

**Backend only**

- [ ] Added test data for new entity
- [ ] Generated the client api if there are new or deleted endpoints and/or DTOs
